### PR TITLE
Refer to `arewewebyet.org` rather than `arewewebyet.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To build web clients with Rust, you can chosse between three libraries:
 
 - [Introducing Pencil: A Microframework Inspired By Flask For Rust](https://fengsp.github.io/blog/2016/3/introducing-pencil/)
 - [Trying Rust for web services](https://blog.wearewizards.io/trying-rust-for-web-services)
-- [Are we web yet?](http://arewewebyet.com/)
+- [Are we web yet?](http://arewewebyet.org/)
 - [Reimplementing ashurbanipal.web in Rust](http://maniagnosis.crsr.net/2015/07/reimplementing-ashurbanipalweb-in-rust.html)
 - [A web app with Nickel: From first line to Heroku deployment](http://blog.thoughtram.io/rust/2015/07/29/a-web-app-with-nickel-from-first-line-to-heroku-deployment.html)
 - [What features Iron does not have compared to a web server like nginx?](https://www.reddit.com/r/rust/comments/3t1mze/what_features_iron_does_not_have_compared_to_a/)


### PR DESCRIPTION
`arewewebyet.org` is up-to-date and contains more information