### PR TITLE
Typo in markdown for Templating#handlebars

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To build web clients with Rust, you can choose between these libraries:
 - **tera**       (-                                                     / [repository](https://github.com/Keats/tera)               / - )
 - **mustache**   (-                                                     / [repository](https://github.com/nickel-org/rust-mustache) / [documentation](http://nickel-org.github.io/rust-mustache))
 - **liquid**     (-                                                     / [repository](https://github.com/cobalt-org/liquid-rust)   / - )
-- **handlebars** (-                                                     / [repository](https://github.com/sunng87/handlebars-rust   / - )
+- **handlebars** (-                                                     / [repository](https://github.com/sunng87/handlebars-rust)  / - )
 - **horrorshow** (-                                                     / [repository](https://github.com/Stebalien/horrorshow-rs)  / [documentation](https://stebalien.github.io/horrorshow-rs/horrorshow/))
 - **maud**       ([homepage](https://lfairy.gitbooks.io/maud/content/)  / [repository](https://github.com/lfairy/maud)              / [documentation](https://lambda.xyz/maud/maud/))
 


### PR DESCRIPTION
I happen to try to open the link and it did not work. 