### PR TITLE
Update hyper info and remove h2 (it's under hyperium organization now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,24 +76,23 @@ Since [WASM](http://webassembly.org/) support is available in most browsers we c
 
 ### Low-Level Frameworks
 
-| Name               | hyper                                                        | h2                                                           | tiny-http                                                    |
-| ------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| **License**        | ![Hyper license](https://img.shields.io/crates/l/hyper.svg?label=%20) | ![H2 license](https://img.shields.io/crates/l/h2.svg?label=%20) | ![Tiny-http license](https://img.shields.io/crates/l/tiny-http.svg?label=%20) |
-| **Version**        | ![Hyper version](https://img.shields.io/crates/v/hyper.svg?label=%20) | ![H2 version](https://img.shields.io/crates/v/h2.svg?label=%20) | ![Tiny-http version](https://img.shields.io/crates/v/tiny-http.svg?label=%20) |
-| **Github Stars**   | ![Hyper stars](https://img.shields.io/github/stars/hyperium/hyper.svg?label=%20) | ![H2 stars](https://img.shields.io/github/stars/carllerche/h2.svg?label=%20) | ![Tiny-http stars](https://img.shields.io/github/stars/tiny-http/tiny-http.svg?label=%20) |
-| **Contributors**   | ![Hyper contributors](https://img.shields.io/github/contributors/hyperium/hyper.svg?label=%20) | ![H2 contributors](https://img.shields.io/github/contributors/carllerche/h2.svg?label=%20) | ![Tiny-http contributors](https://img.shields.io/github/contributors/tiny-http/tiny-http.svg?label=%20) |
-| **Activity**       | ![Hyper activity](https://img.shields.io/github/commit-activity/y/hyperium/hyper.svg?label=%20) | ![H2 activity](https://img.shields.io/github/commit-activity/y/carllerche/h2.svg?label=%20) | ![Tiny-http activity](https://img.shields.io/github/commit-activity/y/tiny-http/tiny-http.svg?label=%20) |
-| **Server**         | yes                                                          | yes                                                          | yes                                                          |
-| **Client**         | yes                                                          | yes                                                          | ?                                                            |
-| **HTTPS support**  | yes                                                          | no                                                           | yes                                                          |
-| **HTTP/2 support** | solicit                                                      | yes                                                          | ?                                                            |
-| **Async**          | yes                                                          | yes                                                          |                                                              |
+| Name               | hyper                                                        | tiny-http                                                    |
+| ------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| **License**        | ![Hyper license](https://img.shields.io/crates/l/hyper.svg?label=%20) | ![Tiny-http license](https://img.shields.io/crates/l/tiny-http.svg?label=%20) |
+| **Version**        | ![Hyper version](https://img.shields.io/crates/v/hyper.svg?label=%20) | ![Tiny-http version](https://img.shields.io/crates/v/tiny-http.svg?label=%20) |
+| **Github Stars**   | ![Hyper stars](https://img.shields.io/github/stars/hyperium/hyper.svg?label=%20) | ![Tiny-http stars](https://img.shields.io/github/stars/tiny-http/tiny-http.svg?label=%20) |
+| **Contributors**   | ![Hyper contributors](https://img.shields.io/github/contributors/hyperium/hyper.svg?label=%20) | ![Tiny-http contributors](https://img.shields.io/github/contributors/tiny-http/tiny-http.svg?label=%20) |
+| **Activity**       | ![Hyper activity](https://img.shields.io/github/commit-activity/y/hyperium/hyper.svg?label=%20) | ![Tiny-http activity](https://img.shields.io/github/commit-activity/y/tiny-http/tiny-http.svg?label=%20) |
+| **Server**         | yes                                                          | yes                                                          |
+| **Client**         | yes                                                          | ?                                                            |
+| **HTTPS support**  | yes                                                          | yes                                                          |
+| **HTTP/2 support** | h2                                                           | ?                                                            |
+| **Async**          | yes                                                          |                                                              |
 
 If you need a more low level control you can choose between these libraries:
 
-- **hyper**     ([homepage](http://hyper.rs/) / [repository](https://github.com/hyperium/hyper)       / [documentation](http://hyper.rs/hyper))
-- **tiny-http** ( -                           / [repository](https://github.com/frewsxcv/tiny-http))  / [documentation](http://frewsxcv.github.io/tiny-http/tiny_http/index.html))
-- **h2**        ( -                           / [repository](https://github.com/carllerche/h2)        / - )
+- **hyper**     ([homepage](http://hyper.rs/) / [repository](https://github.com/hyperium/hyper)       / [documentation](https://docs.rs/hyper/))
+- **tiny-http** ( -                           / [repository](https://github.com/tiny-http/tiny-http))  / [documentation](https://docs.rs/tiny_http/))
 
 ### Outdated server frameworks
 


### PR DESCRIPTION
The `h2` move into hyperium organization now. And `hyper`'s HTTP/2 support use `h2`. We can probably get rid of the `h2` column.

* https://github.com/hyperium/h2
* https://github.com/hyperium/hyper/blob/960a69a5878ede82c56f50ac1444a9e75e885a8f/Cargo.toml#L34