### PR TITLE
fix images for Nickel and Sailfish

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -401,7 +401,7 @@ crates-io = "kinglet"
 
 [[server]]
 name = "nickel"
-repo = "https://github.com/nickel-org/nickel.rs/"
+repo = "https://github.com/nickel-org/nickel.rs"
 outdated = true
 crates-io = "nickel"
 
@@ -462,7 +462,7 @@ crates-io = "tk-http"
 [[template]]
 name = "sailfish"
 homepage = "https://sailfish.netlify.app"
-repo = "https://github.com/Kogia-sima/sailfish/"
+repo = "https://github.com/Kogia-sima/sailfish"
 crates-io = "sailfish"
 
 [[template]]


### PR DESCRIPTION
I saw a couple of projects with broken images and I think it's because of these trailing slashes.  Ie, the trailing slash on Nickel's repo causes its github stars image path to be: `nickel.rs/.svg`.  Removing the trailing slashes to see if it helps.