### PR TITLE
fix docs.rs links for packages with hyphens

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -467,7 +467,7 @@ struct CratesIoInfo {
 
 fn crates_io_info(name: &str, crates_io: &Option<String>) -> CratesIoInfo {
     if let Some(crate_name) = crates_io {
-        let docs = format!("[![Docs](https://img.shields.io/badge/docs.rs-{crate_name}-green)](https://docs.rs/{crate_name}/)");
+        let docs = format!("[![Docs](https://img.shields.io/static/v1?label=docs.rs&message={crate_name}&color=green)](https://docs.rs/{crate_name}/)");
         let license = format!(
             "![{name} license](https://img.shields.io/crates/l/{crate_name}.svg?label=%20)"
         );


### PR DESCRIPTION
This switches from shields.io's hyphen-separated values to querystring values, which avoids broken links for crates with hyphens in the name.