### PR TITLE
Iced is actively in development

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -130,7 +130,6 @@ ssr = false
 vdom = false
 rendering = "canvas"
 architecture = "tea"
-outdated = true
 
 [[frontend]]
 name = "Vizia"


### PR DESCRIPTION
I don't think it should be marked as outdated.

Its latest version([0.13.1](https://github.com/iced-rs/iced/releases/tag/0.13.1)) is released at Sep 19, 2024, and a new version (maybe 0.14) [is coming](https://github.com/iced-rs/iced/milestone/20).

https://github.com/iced-rs/iced
https://github.com/iced-rs/iced/releases
https://github.com/iced-rs/iced/graphs/contributors

---

In an old commit Iced was marked as outdated, but with on reason: https://github.com/flosse/rust-web-framework-comparison/commit/2f3f62113f7ccae9b0ddfe5ff5823843c5c3f49d

----

UPDATE: yes, https://github.com/iced-rs/iced_web is outdated. (iced itself is not a web front framework.) CLOSING.