### PR TITLE
feat: add the ntex framework to server listing

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -279,6 +279,16 @@ async = true
 client = false
 
 [[server]]
+name = "ntex"
+repo = "https://github.com/ntex-rs/ntex"
+crates-io = "ntex"
+https = true
+http2 = true
+base = "ntex-rt"
+async = true
+client = true
+
+[[server]]
 name = "rocket"
 homepage = "https://rocket.rs"
 repo = "https://github.com/SergioBenitez/rocket"


### PR DESCRIPTION
Somebody suggested this in #170 but didn't submit a PR, so I am following up here.

I came across it when looking into axum then actix. I read that ntex came from one of the developers of actix-web, who didn't want to be using `Send` + `Sync` in all of their code (which is required in situations using tokio as the async runtime).